### PR TITLE
Make manifest.json theme color match new color scheme

### DIFF
--- a/app/assets/json/manifest.json.erb
+++ b/app/assets/json/manifest.json.erb
@@ -3,7 +3,7 @@
   "shortname": "Tracker",
   "start_url": "/",
   "display": "browser",
-  "theme_color": "#f7b551",
+  "theme_color": "#ccf0c3",
   "background_color": "#ffffff",
   "icons": [
     {


### PR DESCRIPTION
Just hardcoding the value again for now. I think I want to move this and
all the related images Webpacker and then share the color somehow so I
don't have to hard code, but leaving that for now.